### PR TITLE
Add requirements for Django 5 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Consulta la documentación oficial en [https://digital.gob.cl/](https://digital.
 
 ## 📖 Documentación
 
-- **Ejemplos de uso**: Ver el directorio `exampleDjango2.2.3/`.
+- **Ejemplos de uso**: Ver los directorios `exampleDjango2.2.3/` y `exampleDjango5/`.
 - **Changelog**: Todas las actualizaciones están documentadas en el archivo `CHANGELOG.md`.
 
 ---

--- a/exampleDjango5/requirements.txt
+++ b/exampleDjango5/requirements.txt
@@ -1,0 +1,4 @@
+Django==5.1.3
+git+https://github.com/felileivas/django-clave-unica.git
+requests==2.32.3
+urllib3==2.2.3


### PR DESCRIPTION
## Summary
- add a `requirements.txt` for the Django 5 example
- mention both example directories in the documentation
- use repository installation path for Django 5 example requirements

## Testing
- `python -m pip install -r exampleDjango5/requirements.txt` *(fails: CONNECT tunnel failed)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f729eb8cc8325bf7867d0a53860d7