### PR TITLE
Fix MANIFEST.in references

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include LICENSE
-include README.rst
+include README.md
 recursive-include clave_unica_auth/lib *
 recursive-include clave_unica_auth/templates *
-recursive-include docs *


### PR DESCRIPTION
## Summary
- update MANIFEST.in to reference README.md
- remove stale docs directory entry
- confirm `python setup.py sdist` runs without warnings

## Testing
- `python setup.py sdist`

------
https://chatgpt.com/codex/tasks/task_e_684ac26b80288325ad408ccd6eeb2c52